### PR TITLE
Feature/add comment dockeryml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 logs/app.log
 docker/db/data/*
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   sample-db:
     image: mysql:5.7
+    platform: linux/amd64 #M1チップの為の記述
     container_name: sample-db
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
M1チップでは現在の設定では使用できないため、docker-compose.ymlファイルにM1チップの為のコードを追記。
DS_Storeファイルが不要生成されるためgit_ignoreファイルに追記。